### PR TITLE
Update 2024-05-03 1443H

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1768,6 +1768,12 @@ Version Syntax : Update yyyy-mm-dd HHMM(H), Author
     - Updated document 'compilation.md' in 'Docs/Linux/packages/Build from Source/packages/fastfetch-cli/fastfetch/'
         + Added instructions to manually install fastfetch into the system
         + Added instructions to manually uninstall fastfetch from the system
-    - Docs/Programming/Languages/Python/Libraries/packages-masterlist.md
+    - Updated document 'Docs/Programming/Languages/Python/Libraries/packages-masterlist.md'
         + Added python library 'sqlite3'
+
+#### 1443H
+- Updates
+    - Updated document 'manual.md' in 'Docs/Programming/Languages/Python/Libraries/sqlite3'
+        + Added function documentation for 'sqlite3.Connection().rollback()' to rollback any non-committed transactions back to the baseline
+        + Added usages and operational workflow usages for '.rollback()'
 

--- a/Docs/Programming/Languages/Python/Libraries/sqlite3/manual.md
+++ b/Docs/Programming/Languages/Python/Libraries/sqlite3/manual.md
@@ -76,6 +76,10 @@
             - Similar to how in 'git' where you need to 'confirm' the changes you have made by committing the changes made into the git repository database
                 + RDBMS Databases like SQLite requires committing all changes made to the database as any changes made and actions taken are ephemeral (is temporary) and will revert back when the database is closed without committing
     + `.execute(sql_stmt, parameterized_values, optionals, ...)` : This routine is a shortcut/wrapper of `cursor.execute()` provided by the cursor object, and it creates an intermediate cursor object by calling the `conn.cursor()` function then calls `cur.execute()` with the parameters given
+    - `.rollback()` : Rollback to the start of any pending transaction. 
+        - Notes:
+            + If autocommit is True, or there is no open transaction, this method does nothing.
+            + If autocommit is False, a new transaction is implicitly opened if a pending transaction was rolled back by this method
 
 - sqlite3.Cursor()
     + `.close()` : Close the database cursor pointer object after usage
@@ -285,6 +289,11 @@
         blob.close()
     ```
 
+- Rollback any changes made to the database if you want to cancel changes
+    ```python
+    conn.rollback()
+    ```
+
 - Commit all changes made to the database
     - Explanation
         - Similar to how in 'git' where you need to 'confirm' the changes you have made by committing the changes made into the git repository database
@@ -430,6 +439,11 @@
         ```python
         rows = cur.fetchall(N)
         ```
+
+- Rollback any changes made to the database if you want to cancel changes
+    ```python
+    conn.rollback()
+    ```
 
 - Commit all changes made to the database
     - Explanation


### PR DESCRIPTION
### 2024-05-03 1443H
- Updates
    - Updated document 'manual.md' in 'Docs/Programming/Languages/Python/Libraries/sqlite3'
        + Added function documentation for 'sqlite3.Connection().rollback()' to rollback any non-committed transactions back to the baseline
        + Added usages and operational workflow usages for '.rollback()'