### PR TITLE
Updates [2024-05-16 0946H - 2024-05-20 1932H] : Merging Development to main

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1868,3 +1868,11 @@ Version Syntax : Update yyyy-mm-dd HHMM(H), Author
 - New
     + Added new document 'multithreaded-command-execution.md' in 'Docs/Programming/Languages/Python/Examples/Code-Snippets/' for Multithreaded system command execution
 
+#### 1831H
+- New
+    - Added new directory for plugin 'oil.nvim' in 'Docs/Programming/Vim/Distros/Neovim/Plugins/docs/'
+        + Added new document 'README.md
+- Updates
+    - Updated document 'packages-list.md' in 'Docs/Programming/Vim/Distros/Neovim/Plugins/docs/'
+        + Added new plugin entry 'stevearc/oil.nvim'
+

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -88,6 +88,7 @@
 + [2024-05-15](#2024-05-15)
 + [2024-05-16](#2024-05-16)
 + [2024-05-17](#2024-05-17)
++ [2024-05-20](#2024-05-20)
 
 ## Version History
 ```
@@ -1882,4 +1883,24 @@ Version Syntax : Update yyyy-mm-dd HHMM(H), Author
 - Updates
     - Updated document 'jq.md' in 'Docs/Linux/packages/'
         + Added usage to retrieve/list all elements/items in an array/arraylist/list
+
+### 2024-05-20
+#### 1443H
+- New
+    - Added new directory 'Tutorials' in 'Docs/Programming/Languages/Rust/' for Rust Tutorials to concepts and topics
+        - Added new directory 'Topics' for Rust Topics
+            - Added new directory 'Iteration' for Rust Iteration of iterable/loopable container objects
+                + Added new document 'for-loop.md' for documentation on Rust 'for' keyword
+
+- Updates
+    - Docs/Programming/Languages/Rust/Libraries/built-in/std.md
+        - Added documentation on Rust (sub)process command execution
+            - Classes and Objects
+                + '::process'
+                + '::Command'
+            + Snippet/Usage of command subprocess execution in Rust
+        + Added new snippet/usage on checking the platform/operating system
+        - Added documentation on new Rust standard library functions
+            + '.to_string()'
+
 

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -87,6 +87,7 @@
 + [2024-05-08](#2024-05-08)
 + [2024-05-15](#2024-05-15)
 + [2024-05-16](#2024-05-16)
++ [2024-05-17](#2024-05-17)
 
 ## Version History
 ```
@@ -1875,4 +1876,10 @@ Version Syntax : Update yyyy-mm-dd HHMM(H), Author
 - Updates
     - Updated document 'packages-list.md' in 'Docs/Programming/Vim/Distros/Neovim/Plugins/docs/'
         + Added new plugin entry 'stevearc/oil.nvim'
+
+### 2024-05-17
+#### 1452H
+- Updates
+    - Updated document 'jq.md' in 'Docs/Linux/packages/'
+        + Added usage to retrieve/list all elements/items in an array/arraylist/list
 

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -86,6 +86,7 @@
 + [2024-05-07](#2024-05-07)
 + [2024-05-08](#2024-05-08)
 + [2024-05-15](#2024-05-15)
++ [2024-05-16](#2024-05-16)
 
 ## Version History
 ```
@@ -1855,4 +1856,11 @@ Version Syntax : Update yyyy-mm-dd HHMM(H), Author
         + Added new attribute to module 'os': '.sep'
         + Added new documentation for function 'os.path.join()'
         + Added new usages for manipulating path
+
+### 2024-05-16
+#### 0946H
+- Updates
+    - Updated document 'manual.md' in 'Docs/Programming/Languages/Python/Libraries/os/'
+        + Added new function entry for 'os.walk()'
+        + Added new usage for 'os.walk()': Tree Traversal
 

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1864,3 +1864,7 @@ Version Syntax : Update yyyy-mm-dd HHMM(H), Author
         + Added new function entry for 'os.walk()'
         + Added new usage for 'os.walk()': Tree Traversal
 
+#### 1009H
+- New
+    + Added new document 'multithreaded-command-execution.md' in 'Docs/Programming/Languages/Python/Examples/Code-Snippets/' for Multithreaded system command execution
+

--- a/Docs/Linux/packages/jq.md
+++ b/Docs/Linux/packages/jq.md
@@ -99,6 +99,11 @@ jq (JSON Query) is a JSON Parser CLI utility that will take a JSON string as inp
     jq .[key] < [file-name]
     ```
 
+- To list all elements/items in an array/arraylist/list
+    ```bash
+    jq '.key[]'
+    ```
+
 - To select a specific value of a key from a JSON (Key-Value) entry without the raw string quotes
     ```console
     jq -r .[key] < [file-name]
@@ -241,6 +246,7 @@ jq (JSON Query) is a JSON Parser CLI utility that will take a JSON string as inp
 ## Wiki
 
 ## Resources
++ [StackOverflow - Questions - 45523425 - Getting all the values of an array with jq](https://stackoverflow.com/questions/45523425/getting-all-the-values-of-an-array-with-jq)
 
 ## References
 + [YouTube - ThePrimeTime - The BEST CLI Tool](https://www.youtube.com/watch?v=n8sOmEe2SDg)

--- a/Docs/Programming/Languages/Python/Examples/Code-Snippets/multithreaded-command-execution.md
+++ b/Docs/Programming/Languages/Python/Examples/Code-Snippets/multithreaded-command-execution.md
@@ -1,0 +1,104 @@
+# Command Execution with Multithreading in Python
+
+## Operational Workflow
+1. You (the user) define all the commands you wish to execute
+2. For all elements in the list of commands you wish to execute (aka 'tasks'), Create a new thread
+3. Execute all the threads in the pool concurrently
+4. Wait for the tasks to be completed
+5. Receive all standard outputs (if any)
+
+## Snippets
+
+- Multithreaded concurrent command execution
+    ```python
+    import os
+    import sys
+    import threading
+    from subprocess import Popen, PIPE
+
+    results = []
+    def exec(task, test_command=False):
+        """
+        Execute the given task
+        """
+        # Check if flag 'test_command' is Enabled
+        if test_command:
+            # Debug: Only print out the command/task to validate
+            print("Executing: {}".format(task))
+        else:
+            # Sanitization: Convert the task command list elements into string before proceeding
+            for i in range(len(task)): task[i] = str(task[i])
+
+            # Open a Subprocess pipe and execute the task command
+            with Popen(task, stdout=PIPE, stdin=PIPE, stderr=PIPE) as proc:
+                # Execute task and communicate
+                res = proc.communicate()
+                stdout = res[0]
+                stderr = res[1]
+
+            # Decode if any
+            if stdout != "":
+                stdout = stdout.decode("utf-8")
+            if stderr != "":
+                stderr = stderr.decode("utf-8")
+
+            # Return result of current task
+            results.append({"task" : task, "stdout" : stdout, "stderr" : stderr})
+
+    def main():
+        # Initialize Variables
+        thread_pool = []
+        threads_status = {} # Container for storing the alive status of all the created threads
+        commands_list = ["your", "commands", "here"]
+
+        # Get argument count
+        number_of_commands = len(commands_list)
+
+        # Calculate number of threads to create
+        number_of_threads = len(number_of_commands)
+
+        # Check if there are any tasks
+        if number_of_commands > 0:
+            for i in range(number_of_threads):
+                # Get current task
+                task = commands_list[i]
+
+                # Initialize new Thread for the current task
+                thread = threading.Thread(target=exec, args=(task,))
+
+                # Store current thread in a thread pool
+                thread_pool.append(thread)
+
+            # Iterate through all threads in the pool and start
+            for thread in thread_pool: 
+                print("[i] Starting thread: {}".format(thread.name))
+                thread.start()
+
+            # Create a mapping of the created threads in the threads_status container for storing the alive status of the threads
+            for thread in thread_pool:
+                threads_status[thread] = thread.is_alive()
+
+            # Iterate through all threads in the pool and wait for the thread to complete
+            for thread in thread_pool: 
+                print("[i] Waiting for thread to complete: {}".format(thread.name))
+                thread.join()
+
+            print("[+] Threads completed.")
+
+            # Print results
+            for i in range(len(results)):
+                # Get current result
+                curr_task = results[i]
+
+                # Iterate through current task
+                for k,v in curr_task.items():
+                    print("{} = {}".format(k,v))
+
+                print("")
+        else:
+            print("[i] No arguments provided.")
+
+    if __name__ == "__main__":
+        main()
+    ```
+

--- a/Docs/Programming/Languages/Python/Libraries/os/manual.md
+++ b/Docs/Programming/Languages/Python/Libraries/os/manual.md
@@ -49,6 +49,27 @@ OS is a built-in python library to provide a portable way of handling Operating 
         - Return
             - pid : The current process's ID
                 + Type: Integer
+    - `.walk(top_level_dir)` : Walk through all directories and subdirectories starting from the root/top-level directory down the tree
+        - Parameter Signature/Header
+            - top_level_dir : Specify the top level root directory to start the digging from
+                + Type: String
+                - Explanation
+                    - python will dig and traverse through every branch (directory) and 
+                        + store the current branch's directory name into index [0] of the current branch's list entry
+                        + store every subbranches (subdirectories) into index [1] of the current branch's list entry
+                        + store every file contents in the current branch into index [2] of the current branch's list entry
+        - Return
+            - tree_contents : os.walk() will return a list of tuples where each tuple is
+                - Type: Iterable<tuple<String, List, List>>
+                - Contents
+                    1. Current path
+                        + Type: String
+                    2. Nested subdirectories in directory branch
+                        + Type: Tuple
+                    3. Files in directory branch
+                        + Type: Tuple
+        - Notes
+            + Convert the returned object into a list using `list(os.walk(top_level_dir))` to manage the generator object as a list
 
 - os.environ
     - .get(env_variable_key) : Get value of the Environment Variable
@@ -152,6 +173,43 @@ OS is a built-in python library to provide a portable way of handling Operating 
     import os
 
     path = os.path.join("top-level-directory-path", "additional", "paths")
+    ```
+
+- Tree Traversal 
+    - Explanation
+        + Walk through all directories and subdirectories starting from the root/top-level directory down the tree
+        - os.walk() will return a list of tuples where each tuple is
+            + [0] = String, Current path
+            + [1] = Tuple, Nested subdirectories in directory branch
+            + [2] = Tuple, Files in directory branch
+    ```python
+    import os
+
+    # Initialize Variables
+    tree_branch_mappings = {
+        # path : { directories : [subdirectories in current directory], files : [files in current directory], },
+    }
+    top_level_dir = "."
+
+    # Begin walking through the tree and navigate through all nested directories and subdirectories and the files within
+    tree_iterable = list(os.walk(top_level_dir))
+
+    # Iterate through tree iterable
+    for i in range(len(tree_iterable)):
+        # Get current branch
+        curr_branch = tree_iterable[i]
+
+        # Get branch tuple objects
+        curr_path = curr_branch[0]
+        curr_dir_dirs = curr_branch[1]
+        curr_dir_files = curr_branch[2]
+
+        # Check if path is in mapping
+        if curr_path not in tree_branch_mappings:
+            tree_branch_mappings[curr_path] = {"directories" : curr_dir_dirs, "files" : curr_dir_files}
+ 
+    # Output
+    return tree_branch_mappings
     ```
 
 ## Wiki

--- a/Docs/Programming/Languages/Rust/Tutorials/Topics/Iteration/for-loop.md
+++ b/Docs/Programming/Languages/Rust/Tutorials/Topics/Iteration/for-loop.md
@@ -1,0 +1,205 @@
+# Rust - Tutorial - Topics: Iteration - For Loops
+
+## Information
+
+### Description
+- Performing iterations over iterable/iterative objects
+    - such as
+        + Arrays (Index-based ordered containers; aka ArrayLists, Vectors, Lists) and
+        + Dictionaries (Key-Value mappings; aka maps, HashMap, Associative Arrays)
+
+### Theory/Concept
+- A for loop is equivalent to a loop expression containing a match expression
+    - For Loop
+        ```rust
+        'label: for PATTERN in iter_expr {
+            /* Loop Body */
+        }
+        ```
+    - Match-case expression
+        ```rust
+        // Initialize a Switch/Match-case comparison expression,
+        // the result of the block statements will be returned to the variable 'result'
+        let result = match IntoIterator::into_iter(iter_expr) {
+            // Define your case
+            mut iter => 'label: loop {
+                // Initialize a mutable variable for the next value/element
+                let mut next;
+
+                // Match the next array element
+                match Iterator::next(&mut iter) {
+                    // Case: If the value of 'val' is not empty, store 'val' into the variable 'next'
+                    Option::Some(val) => next = val,
+                    // Case: If there are no values, break the loop
+                    Option::None => break,
+                };
+
+                // Set the PATTERN to the next element
+                let PATTERN = next;
+
+                // Initialize a new loop
+                let () = {
+                    // Loop Body
+                };
+            },
+        };
+
+        // Use the 'result' variable
+        ```
+
+## Documentations
+
+### Keywords
++ for : For iterating through iterable containers using a pattern
+
+### Synopsis/Syntax
+- For loop
+    - Explanation
+        + PATTERN refers to the variable that will store the current element during the looping of an iterable (i.e. array/arraylist/list/vector etc etc) matching the specified expression
+        - EXPRESSION refers to a set of conditions that the for loop will follow while looping
+            - There are various types of expressions
+                + array : Using the array/iterable container object directly. The for loop will loop through every element in the array, with each element being placed into 'PATTERN' when the cursor is back at the top of the loop
+                + range : Use the structure/format 'min..max' to invoke a range for loop. This is used to iterate through a defined set of numbers between a given minimum value and a maximum value
+    - Default
+        ```rust
+        for PATTERN in EXPRESSION {
+            // Statements
+        }
+        ```
+    - Array/Iterable
+        - Variable
+            ```rust
+            for element in arr {
+                // Statements
+            }
+            ```
+        - In-line definition
+            ```rust
+            for element in ["elements", "here"] {
+                // Statements
+            }
+            ```
+    - Range
+        - Notes
+            - Before rustc-1.0.0-nightly
+                + `for n in min..max` was the same as `for n in range(min, max)`
+        ```rust
+        for n in min..max {
+            // Statements
+        }
+        ```
+    - Pointer iterable
+        ```rust
+        for ptr in arr.iter() {
+            // Statements
+        }
+        ```
+    - Index-Element mapping
+        - Explanation
+            - This will return a tuple containing the following of the current elment
+                1. Current element index
+                2. Element value
+        ```rust
+        for (i, element) in arr.iter().enumerate() {
+            // Statements
+        }
+        ```
+
+### Usage
+
+> using For Loop
+
+- Initialize an array(s)
+    ```rust
+    let arr = &["your", "elements", "here"];
+    ```
+
+- Loop/Iterate through the array using the elements directly (no index)
+    ```rust
+    for element in arr {
+        // Print the current element
+        println!("{}", element);
+    }
+    ```
+
+- Loop/Iterate through an array containing a range/series of integers
+    ```rust
+    // Iterate through the range of numbers between min and max
+    for n in min..max {
+        // Statements dealing with current number 'n'
+    }
+    ```
+
+- Loop/Iterate through an array using the pointer of the iterable
+    - Notes
+        - The loop items are borrowed references to the iteratee elements. 
+            - In this case, 
+                + the elements of strs have type &'static str - they are borrowed pointers to static strings. 
+                + This means sptr has type &&'static str, so we dereference it as *sptr. 
+            - An alternative form is
+                ```rust
+                for &element in arr.iter() {
+                    println!("{}", element);
+                }
+                ```
+    ```rust
+    for ptr in arr.iter() {
+        // Statements
+        println!("{}", ptr);
+    }
+    ```
+
+- Loop/Iterate through an array and return a tuple containing an Index-Element mapping
+    - Explanation
+        - This will return a tuple containing the following of the current elment
+            1. Current element index
+            2. Element value
+    ```rust
+    for (i, element) in arr.iter().enumerate() {
+        // Statements
+        println!("String #{} is {}", i, s);
+    }
+    ```
+
+### Snippets
+
+- Initialize an array(s)
+    ```rust
+    let str_list = &["apples", "cake", "coffee"];
+    let int_list = &[1, 2, 3, 4];
+    ```
+
+- Loop/Iterate through the array using the elements directly (no index)
+    ```rust
+    for element in str_list {
+        // Print the current element
+        println!("{}", element);
+    }
+    ```
+
+- Loop/Iterate through an array containing a range/series of integers and sum them
+    ```rust
+    // Initialize variables
+    let mut sum:uint32 = 0;
+    let min:uint32 = 1;
+    let max:uint32 = 11;
+
+    // Iterate through the range of numbers between min and max
+    for n in min..max {
+        // Accumulate/increment the sum by n
+        sum += n;
+    }
+    ```
+
+## Wiki
+
+## Resources
++ [Rustlang Documentations - std - iter](http://doc.rust-lang.org/std/iter/index.html)
++ [Rustlang Documentations - std - iter - trait.Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.enumerate)
+
+## References
++ [Rustlang Documentations - Reference - Expressions - Loop](https://doc.rust-lang.org/reference/expressions/loop-expr.html)
++ [StackOverflow - Questions - 9271970 - How do you make a range in Rust](https://stackoverflow.com/questions/9271970/how-do-you-make-a-range-in-rust)
+
+## Remarks
+

--- a/Docs/Programming/Vim/Distros/Neovim/Plugins/docs/oil.nvim/README.md
+++ b/Docs/Programming/Vim/Distros/Neovim/Plugins/docs/oil.nvim/README.md
@@ -1,0 +1,506 @@
+# Neovim Plugin: oil.nvim
+
+## Information
+### Project
++ Project Author: stevearc
++ Project Name: oil.nvim
+- Repositories
+    + GitHub: https://github.com/stevearc/oil.nvim
+
+### Description
+- oil.nvim is a Neovim File Explorer/Manager that lets you edit your filesystem like a buffer with varying degree of customization
+
+## Setup
+### Dependencies
+- Neovim Plugins
+    + nvim-tree/nvim-web-devicons
+
+### Pre-Requisites
+
+### Installation
+
+> Using lazy plugin manager
+
+```lua
+{
+    "stevearc/oil.nvim",
+    -- Package Optionals
+    opts = {},
+    -- Optional Dependencies
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    -- Configurations
+    config = function()
+        require('path.to.oil.lua')
+    end
+}
+```
+
+### Configurations
+
+- Import plugin library/package
+    ```lua
+    local oil = require('oil')
+    ```
+
+- Setup plugin
+    ```lua
+    oil.setup({
+      -- Oil will take over directory buffers (e.g. `vim .` or `:e src/`)
+      -- Set to false if you still want to use netrw.
+      default_file_explorer = true,
+      -- Id is automatically added at the beginning, and name at the end
+      -- See :help oil-columns
+      columns = {
+        "icon",
+        -- "permissions",
+        -- "size",
+        -- "mtime",
+      },
+      -- Buffer-local options to use for oil buffers
+      buf_options = {
+        buflisted = false,
+        bufhidden = "hide",
+      },
+      -- Window-local options to use for oil buffers
+      win_options = {
+        wrap = false,
+        signcolumn = "no",
+        cursorcolumn = false,
+        foldcolumn = "0",
+        spell = false,
+        list = false,
+        conceallevel = 3,
+        concealcursor = "nvic",
+      },
+      -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
+      delete_to_trash = false,
+      -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
+      skip_confirm_for_simple_edits = false,
+      -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
+      -- (:help prompt_save_on_select_new_entry)
+      prompt_save_on_select_new_entry = true,
+      -- Oil will automatically delete hidden buffers after this delay
+      -- You can set the delay to false to disable cleanup entirely
+      -- Note that the cleanup process only starts when none of the oil buffers are currently displayed
+      cleanup_delay_ms = 2000,
+      lsp_file_methods = {
+        -- Time to wait for LSP file operations to complete before skipping
+        timeout_ms = 1000,
+        -- Set to true to autosave buffers that are updated with LSP willRenameFiles
+        -- Set to "unmodified" to only save unmodified buffers
+        autosave_changes = false,
+      },
+      -- Constrain the cursor to the editable parts of the oil buffer
+      -- Set to `false` to disable, or "name" to keep it on the file names
+      constrain_cursor = "editable",
+      -- Set to true to watch the filesystem for changes and reload oil
+      experimental_watch_for_changes = false,
+      -- Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
+      -- options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
+      -- Additionally, if it is a string that matches "actions.<name>",
+      -- it will use the mapping at require("oil.actions").<name>
+      -- Set to `false` to remove a keymap
+      -- See :help oil-actions for a list of all available actions
+      keymaps = {
+        ["g?"] = "actions.show_help",
+        ["<CR>"] = "actions.select",
+        ["<C-s>"] = "actions.select_vsplit",
+        ["<C-h>"] = "actions.select_split",
+        ["<C-t>"] = "actions.select_tab",
+        ["<C-p>"] = "actions.preview",
+        ["<C-c>"] = "actions.close",
+        ["<C-l>"] = "actions.refresh",
+        ["-"] = "actions.parent",
+        ["_"] = "actions.open_cwd",
+        ["`"] = "actions.cd",
+        ["~"] = "actions.tcd",
+        ["gs"] = "actions.change_sort",
+        ["gx"] = "actions.open_external",
+        ["g."] = "actions.toggle_hidden",
+        ["g\\"] = "actions.toggle_trash",
+      },
+      -- Set to false to disable all of the above keymaps
+      use_default_keymaps = true,
+      view_options = {
+        -- Show files and directories that start with "."
+        show_hidden = false,
+        -- This function defines what is considered a "hidden" file
+        is_hidden_file = function(name, bufnr)
+          return vim.startswith(name, ".")
+        end,
+        -- This function defines what will never be shown, even when `show_hidden` is set
+        is_always_hidden = function(name, bufnr)
+          return false
+        end,
+        -- Sort file names in a more intuitive order for humans. Is less performant,
+        -- so you may want to set to false if you work with large directories.
+        natural_order = true,
+        sort = {
+          -- sort order can be "asc" or "desc"
+          -- see :help oil-columns to see which columns are sortable
+          { "type", "asc" },
+          { "name", "asc" },
+        },
+      },
+      -- Extra arguments to pass to SCP when moving/copying files over SSH
+      extra_scp_args = {},
+      -- EXPERIMENTAL support for performing file operations with git
+      git = {
+        -- Return true to automatically git add/mv/rm files
+        add = function(path)
+          return false
+        end,
+        mv = function(src_path, dest_path)
+          return false
+        end,
+        rm = function(path)
+          return false
+        end,
+      },
+      -- Configuration for the floating window in oil.open_float
+      float = {
+        -- Padding around the floating window
+        padding = 2,
+        max_width = 0,
+        max_height = 0,
+        border = "rounded",
+        win_options = {
+          winblend = 0,
+        },
+        -- This is the config that will be passed to nvim_open_win.
+        -- Change values here to customize the layout
+        override = function(conf)
+          return conf
+        end,
+      },
+      -- Configuration for the actions floating preview window
+      preview = {
+        -- Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
+        -- min_width and max_width can be a single value or a list of mixed integer/float types.
+        -- max_width = {100, 0.8} means "the lesser of 100 columns or 80% of total"
+        max_width = 0.9,
+        -- min_width = {40, 0.4} means "the greater of 40 columns or 40% of total"
+        min_width = { 40, 0.4 },
+        -- optionally define an integer/float for the exact width of the preview window
+        width = nil,
+        -- Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
+        -- min_height and max_height can be a single value or a list of mixed integer/float types.
+        -- max_height = {80, 0.9} means "the lesser of 80 columns or 90% of total"
+        max_height = 0.9,
+        -- min_height = {5, 0.1} means "the greater of 5 columns or 10% of total"
+        min_height = { 5, 0.1 },
+        -- optionally define an integer/float for the exact height of the preview window
+        height = nil,
+        border = "rounded",
+        win_options = {
+          winblend = 0,
+        },
+        -- Whether the preview window is automatically updated when the cursor is moved
+        update_on_cursor_moved = true,
+      },
+      -- Configuration for the floating progress window
+      progress = {
+        max_width = 0.9,
+        min_width = { 40, 0.4 },
+        width = nil,
+        max_height = { 10, 0.9 },
+        min_height = { 5, 0.1 },
+        height = nil,
+        border = "rounded",
+        minimized_border = "none",
+        win_options = {
+          winblend = 0,
+        },
+      },
+      -- Configuration for the floating SSH window
+      ssh = {
+        border = "rounded",
+      },
+      -- Configuration for the floating keymaps help window
+      keymaps_help = {
+        border = "rounded",
+      },
+    })
+    ```
+
+- Set the harpoon keybinding/keymappings
+    - To Mimic the `vim-vinegar` method of navigating to the parent directory of a file
+        ```lua
+        vim.keymap.set("n", "-", "<CMD>Oil<CR>", { desc = "Open parent directory" })
+        ```
+
+## Documentations
+
+### Default Movements
++ `<CR>` : To open a file/directory
++ `-` : To go up a directory
++ Treat the movements like a normal buffer and make changes as you like
+- `:w` : To confirm that you're done and commit to actually perform the actions; 
+    - Notes
+        + oil works like a database and git commits where it stores the actions in the buffer until the user confirms that they commit that they want to perform the stored actions
+
+### Plugin setup configuration settings
+- `default_file_explorer = true` : Oil will take over directory buffers (e.g. `vim .` or `:e src/`)
+  + Set to false if you still want to use netrw.
+- `columns = {"icon", "permissions", "size", "mtime",}` : Id is automatically added at the beginning, and name at the end
+    - Notes
+      - See `:help oil-columns`
++ `buf_options = {buflisted = false,bufhidden = "hide",}` : Buffer-local options to use for oil buffers
++ `win_options = {wrap = false, signcolumn = "no", cursorcolumn = false, foldcolumn = "0", spell = false, list = false, conceallevel = 3, concealcursor = "nvic",}` : Window-local options to use for oil buffers
++ `delete_to_trash = false` : Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
++ skip_confirm_for_simple_edits = false : Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
+- `prompt_save_on_select_new_entry = true` : Selecting a new/moved/renamed file or directory will prompt you to save changes first
+  - Notes
+    + See `:help prompt_save_on_select_new_entry`
+- `cleanup_delay_ms = 2000` : Oil will automatically delete hidden buffers after this delay
+    - Notes
+        + You can set the delay to false to disable cleanup entirely
+        + Note that the cleanup process only starts when none of the oil buffers are currently displayed
+- `lsp_file_methods = {}` : LSP File Methods
+    - Setting Key-Values
+        - timeout_ms = 1000 : Time to wait for LSP file operations to complete before skipping
+            - Notes
+                + Set to true to autosave buffers that are updated with LSP willRenameFiles
+        - `autosave_changes = false` : Set to "unmodified" to only save unmodified buffers
+- `constrain_cursor` = "editable" : Constrain the cursor to the editable parts of the oil buffer
+    - Notes
+        + Set to `false` to disable, or "name" to keep it on the file names
++ `experimental_watch_for_changes = false` : Set to true to watch the filesystem for changes and reload oil
+- `keymaps = { ["mapping"] = "action.function" }` : Keymaps in oil buffer. Can be any value that `vim.keymap.set` accepts OR a table of keymap
+    - Notes
+        + options with a `callback` (e.g. { callback = function() ... end, desc = "", mode = "n" })
+        + Additionally, if it is a string that matches "actions.<name>", it will use the mapping at require("oil.actions").<name>
+        + Set to `false` to remove a keymap
+        + See :help oil-actions for a list of all available actions
+    - Default/Recommended Keymaps
+        + `["g?"] = "actions.show_help"`
+        + `["<CR>"] = "actions.select"`
+        + `["<C-s>"] = "actions.select_vsplit"`
+        + `["<C-h>"] = "actions.select_split"`
+        + `["<C-t>"] = "actions.select_tab"`
+        + `["<C-p>"] = "actions.preview"`
+        + `["<C-c>"] = "actions.close"`
+        + `["<C-l>"] = "actions.refresh"`
+        + `["-"] = "actions.parent"`
+        + `["_"] = "actions.open_cwd"`
+        + `["`"] = "actions.cd"`
+        + `["~"] = "actions.tcd"`
+        + `["gs"] = "actions.change_sort"`
+        + `["gx"] = "actions.open_external"`
+        + `["g."] = "actions.toggle_hidden"`
+        + `["g\\"] = "actions.toggle_trash"`
++ `use_default_keymaps = true` : Set to false to disable all of the above keymaps
+- `view_options = { setting-key = value }` : 
+    - Options
+        + `show_hidden = false` : Show files and directories that start with "."
+        - `is_hidden_file` : Shows if the file is a hidden file or visible
+            - Using a custom function
+                - This function defines what is considered a "hidden" file
+                    ```lua
+                    is_hidden_file = function(name, bufnr)
+                      return vim.startswith(name, ".")
+                    end,
+                    ```
+        - `is_always_hidden` : Define what will never be shown, even when 'show_hidden' is set
+            - Using a custom function
+                - This function defines what will never be shown, even when `show_hidden` is set
+                    ```lua
+                    is_always_hidden = function(name, bufnr)
+                      return false
+                    end,
+                    ```
+        - `natural_order = true` : Sort file names in a more intuitive order for humans.
+            - Notes:
+                + This is less performant, so you may want to set to false if you work with large directories.
+        - `sort = { {"key", "sort-type"}, ... }` : Sort all specified keys according to the sorting filter keyword
+            - Notes 
+                + sort order can be "asc" or "desc"
+                + see :help oil-columns to see which columns are sortable
+            - Sort Types/Targets
+                + type : Sort file type by the filter keyword
+                + name : Sort file name by the filter keyword
+            - Sorting Filter Keywords
+                + asc : Ascending Order
+                + dsc : Descending Order
+            - Example
+                ```lua
+                sort = {
+                  { "type", "asc" },
+                  { "name", "asc" },
+                },
+                ```
++ `extra_scp_args = {}` : Extra arguments to pass to SCP when moving/copying files over SSH
+- `git = { git-command = function }` : EXPERIMENTAL support for performing file operations with git
+    - Git commands
+        - add
+            ```lua
+            -- Return true to automatically git add files
+            add = function(path)
+              return false
+            end,
+            ```
+        - move
+            ```lua
+            -- Return true to automatically git mv files
+            mv = function(src_path, dest_path)
+              return false
+            end,
+            ```
+        - remove
+            ```lua
+            -- Return true to automatically git rm files
+            rm = function(path)
+              return false
+            end,
+            ```
+- `float = { settings = value, }` : Configuration for the floating window in oil.open_float
+    - Floating window settings
+        + `padding = 2` : Padding around the floating window
+        + `max_width = 0` : Specify the maximum width of the floating window (0 = No maximum)
+        + `max_height = 0` : Specify the maximum height of the floating window (0 = No maximum)
+        - `border = "rounded"` : Specify the border of the floating window
+            - Border Options
+                + rounded : Rounded border and corner
+        - `win_options = { options=values }` : Specify the window options to apply to the floating window
+            - Window Options
+                + `winblend = 0` : Window blend
+        - `override = configuration` : This is the config that will be passed to nvim_open_win.
+            - Notes
+                + Change values here to customize the layout
+            - Override Function
+                ```lua
+                override = function(conf)
+                  return conf
+                end,
+                ```
+- `preview = { settings = values, ... }` : Configuration for the actions floating preview window
+    - Preview Settings
+        - `max_width = 0.9` : Specify the maximum width (horizontal size) of the floating preview window
+            - Notes
+                + Width dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
+                - min_width and max_width can be a single value or a list of mixed integer/float types.
+                    + max_width = {100, 0.8} means "the lesser of 100 columns or 80% of total"
+        - `min_width = { 40, 0.4 }` : Specify the minimum width (horizontal size) of the floating preview window
+            - Notes
+                + min_width = {40, 0.4} means "the greater of 40 columns or 40% of total"
+        + `width = nil` : optionally define an integer/float for the exact width of the preview window
+        - `max_height = 0.9` : Specify the maximum height (vertical size) of the floating preview window
+            - Notes 
+                + Height dimensions can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
+                - min_height and max_height can be a single value or a list of mixed integer/float types.
+                    + max_height = {80, 0.9} means "the lesser of 80 columns or 90% of total"
+        - `min_height = { 5, 0.1 }` : Specify the minimum height (vertical size) of the floating preview window
+            - Notes
+                + min_height = {5, 0.1} means "the greater of 5 columns or 10% of total"
+        + `height = nil` : optionally define an integer/float for the exact height of the preview window; Set as 'nil' to not define
+        - `border = "rounded"` : Specify the border of the floating preview window
+            - Border Options
+                + rounded : Rounded border and corner
+        - `win_options = { options=values }` : Specify the window options to apply to the floating preview window
+            - Window Options
+                + `winblend = 0` : Window blend
+        + `update_on_cursor_moved = true` : Enable/Disable automatic updating of preview window when the cursor is moved
+- `progress = { settings = values, ... }` : Configuration for the floating progress window
+    - Floating progress window
+        + `max_width = 0.9` : Specify the maximum width of the floating progress window
+        + `min_width = { 40, 0.4 }` : Specify the minimum width of the floating progress window
+        + `width = nil` : Specify the startup static width of the floating progress window; Set as 'nil' to not define
+        + `max_height = { 10, 0.9 }` : Specify the maximum height of the floating progress window
+        + `min_height = { 5, 0.1 }` : Specify the minimum height of the floating progress window
+        + `height = nil` : Specify the startup static height of the floating progress window; Set as 'nil' to not define
+        - `border = "rounded"` : Specify the border of the floating progress window
+            - Border Options
+                + rounded : Rounded border and corner
+        - `minimized_border = "none"` : Specify the border of the floating progress window when minimized; Set as 'none' to have no border
+        - `win_options = { options=values }` : Specify the window options to apply to the floating progress window
+            - Window Options
+                + `winblend = 0` : Window blend
+- `ssh = { settings = value, ... }` : Configuration for the floating SSH window
+    - Floating SSH Window
+        - `border = "rounded"` : Specify the border of the floating SSH window
+            - Border Options
+                + rounded : Rounded border and corner
+- `keymaps_help = { settings = value, ... }` : Configuration for the floating keymaps help window
+    - Floating Keymaps help window
+        - `border = "rounded"` : Specify the border of the floating keymaps help window
+            - Border Options
+                + rounded : Rounded border and corner
+
+### Adapters
+#### SSH
+- This adapter allows you to browse files over ssh, much like netrw. 
+    - To use it, simply open a buffer using the following name template:
+        ```bash
+        nvim oil-ssh://[username@]hostname[:port]/[path]
+        ```
+
+### Plugin package
+- oil
+
+### Plugin modules/libraries
+- oil : The Neovim File Explorer/Manager
+
+### Plugin classes
+
+### Plugin functions
+- `get_entry_on_line(bufnr, lnum)` : Get the entries on the specified buffer number and line number (1-indexed)
+    - Parameter Signature/Header
+        + bufnr : Specify the Buffer Number you wish to get the entry from
+        + lnum : Specify the Line number within the buffer number to get
+    - Return
+        - entry : Get the entry on the specified line within the specified buffer number
+            + Type: nil | oil.Entry
++ `get_cursor_entry()` : Get the entry currently under the cursor
++ `discard_all_changes()` : Discord all changes made to the oil buffers
+- `set_columns(cols)` : Change the display columns for oil to the specified columns
+    - Parameter Signature/Header
+        + cols : Specify the column to change the display columns for oil to
++ set_sort(sort)
++ set_is_hidden_file(is_hidden_file)
++ toggle_hidden()
++ get_current_dir()
++ open_float(dir)
++ toggle_float(dir)
++ open(dir)
++ close()
++ open_preview(opts)
++ select(opts, callback)
++ save(opts, cb)
++ setup(opts)
+
+### Plugin attributes/variables
+- oil
+    - `.Entry` : Oil Entry
+
+### Plugin (Auto)Commands
+- `Oil {options} <arguments> [path]` : Open up the specified path as a buffer in the File Explorer/Manager; works with `:edit`
+    - Parameters
+        - Positionals
+            + path : Specify the directory/filepath to edit/open
+        - Optionals
+            - With Arguments
+            - Flags
+                + --float : Open up oil in a floating window
+
+### Snippets
+
+## Usages
+- To open a directory with oil
+    ```lua
+    :Oil <path>
+    ```
+
+- To open oil in a floating window
+    ```lua
+    :Oil --float <path>
+    ```
+
+## Wiki
+
+## Resources
+
+## References
++ [GitHub - stevearc/oilnvim - API](https://github.com/stevearc/oil.nvim/blob/master/doc/api.md)
+
+## Remarks
+

--- a/Docs/Programming/Vim/Distros/Neovim/Plugins/docs/packages-list.md
+++ b/Docs/Programming/Vim/Distros/Neovim/Plugins/docs/packages-list.md
@@ -2,4 +2,5 @@
 
 ## Contents
 + ThePrimeagen/harpoon : Harpoon is a file finder/jumper Neovim Plugin focusing on Quality-of-Life/Coding experience improvements by simplifying the ability to search for files
++ stevearc/oil.nvim : Neovim File Explorer/Manager that lets you edit your filesystem like a buffer
 


### PR DESCRIPTION
### 2024-05-16
#### 0946H
- Updates
    - Updated document 'manual.md' in 'Docs/Programming/Languages/Python/Libraries/os/'
        + Added new function entry for 'os.walk()'
        + Added new usage for 'os.walk()': Tree Traversal

#### 1009H
- New
    + Added new document 'multithreaded-command-execution.md' in 'Docs/Programming/Languages/Python/Examples/Code-Snippets/' for Multithreaded system command execution

#### 1831H
- New
    - Added new directory for plugin 'oil.nvim' in 'Docs/Programming/Vim/Distros/Neovim/Plugins/docs/'
        + Added new document 'README.md
- Updates
    - Updated document 'packages-list.md' in 'Docs/Programming/Vim/Distros/Neovim/Plugins/docs/'
        + Added new plugin entry 'stevearc/oil.nvim'

### 2024-05-17
#### 1452H
- Updates
    - Updated document 'jq.md' in 'Docs/Linux/packages/'
        + Added usage to retrieve/list all elements/items in an array/arraylist/list

### 2024-05-20
#### 1443H
- New
    - Added new directory 'Tutorials' in 'Docs/Programming/Languages/Rust/' for Rust Tutorials to concepts and topics
        - Added new directory 'Topics' for Rust Topics
            - Added new directory 'Iteration' for Rust Iteration of iterable/loopable container objects
                + Added new document 'for-loop.md' for documentation on Rust 'for' keyword

- Updates
    - Docs/Programming/Languages/Rust/Libraries/built-in/std.md
        - Added documentation on Rust (sub)process command execution
            - Classes and Objects
                + '::process'
                + '::Command'
            + Snippet/Usage of command subprocess execution in Rust
        + Added new snippet/usage on checking the platform/operating system
        - Added documentation on new Rust standard library functions
            + '.to_string()'

